### PR TITLE
Restructure graphql types

### DIFF
--- a/app/graphql/mutations/users/signup.rb
+++ b/app/graphql/mutations/users/signup.rb
@@ -1,13 +1,14 @@
 module Mutations
   module Users
     class Signup < Mutations::BaseMutation
+      argument :password, String, required: true
       argument :user_attributes, Types::Users::UserInput, required: false
 
       field :errors, [String], null: true
       field :token, String, null: true
 
-      def resolve(user_attributes:)
-        new_user = ::Users::NewUser.new user_attributes.to_h
+      def resolve(user_attributes:, password:)
+        new_user = ::Users::NewUser.new user_attributes.to_h.merge(password: password)
         new_user.create
       end
     end

--- a/app/graphql/mutations/users/signup.rb
+++ b/app/graphql/mutations/users/signup.rb
@@ -1,14 +1,13 @@
 module Mutations
   module Users
     class Signup < Mutations::BaseMutation
-      argument :password, String, required: true
-      argument :user_attributes, Types::UserAttributes, required: false
+      argument :user_attributes, Types::Users::UserInput, required: false
 
       field :errors, [String], null: true
       field :token, String, null: true
 
-      def resolve(user_attributes:, password:)
-        new_user = ::Users::NewUser.new user_attributes.to_h.merge(password: password)
+      def resolve(user_attributes:)
+        new_user = ::Users::NewUser.new user_attributes.to_h
         new_user.create
       end
     end

--- a/app/graphql/resolvers/current_user.rb
+++ b/app/graphql/resolvers/current_user.rb
@@ -1,6 +1,6 @@
 module Resolvers
   class CurrentUser < Resolvers::Base
-    type Types::UserType, null: true
+    type Types::Users::UserType, null: true
 
     description 'Fetch the info for the current user'
     argument :id, String, required: false, default_value: ''

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -2,14 +2,4 @@ module Types
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument
   end
-
-  class UserAttributes < Types::BaseInputObject
-    argument :email, String, required: true
-    argument :first_name, String, required: true
-    argument :last_name, String, required: true
-    argument :gender, String, required: false
-    argument :country, String, required: false
-    argument :region, String, required: false
-    argument :city, String, required: false
-  end
 end

--- a/app/graphql/types/users/user_input.rb
+++ b/app/graphql/types/users/user_input.rb
@@ -1,7 +1,6 @@
 module Types::Users
   class UserInput < Types::BaseInputObject
     argument :email, String, required: true
-    argument :password, String, required: true
     argument :first_name, String, required: true
     argument :last_name, String, required: true
     argument :gender, String, required: false

--- a/app/graphql/types/users/user_input.rb
+++ b/app/graphql/types/users/user_input.rb
@@ -1,0 +1,12 @@
+module Types::Users
+  class UserInput < Types::BaseInputObject
+    argument :email, String, required: true
+    argument :password, String, required: true
+    argument :first_name, String, required: true
+    argument :last_name, String, required: true
+    argument :gender, String, required: false
+    argument :country, String, required: false
+    argument :region, String, required: false
+    argument :city, String, required: false
+  end
+end

--- a/app/graphql/types/users/user_type.rb
+++ b/app/graphql/types/users/user_type.rb
@@ -1,4 +1,4 @@
-module Types
+module Types::Users
   class AttributesType < Types::BaseObject
     field :email, String, null: false
     field :first_name, String, null: false
@@ -13,7 +13,7 @@ module Types
     field :id, ID, null: false
     field :full_name, String, null: false
     field :token, String, null: false
-    field :user_attributes, Types::AttributesType, null: false
+    field :user_attributes, Types::Users::AttributesType, null: false
     def user_attributes
       object
     end

--- a/spec/graphql/mutations/users/signup_spec.rb
+++ b/spec/graphql/mutations/users/signup_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Mutations::Users::Signup, type: :request do
   let!(:variables) do
     {
-      password: '123456789',
       userAttributes: {
         email: 'vince@example.com',
+        password: '123456789',
         firstName: 'Vince',
         lastName: 'Yoon',
         gender: 'male',
@@ -50,7 +50,7 @@ RSpec.describe Mutations::Users::Signup, type: :request do
 
     context 'with invalid signup info' do
       it 'shorten password length' do
-        response = execute_and_parse_graphql_response query: signup_query, variables: variables.merge(password: '1234')
+        response = execute_and_parse_graphql_response query: signup_query, variables: variables.deep_merge(userAttributes: { password: '123' })
         expect(response['signup']).to match(
           token: 'Invalid',
           errors: ['Password is too short (minimum is 8 characters)']

--- a/spec/graphql/mutations/users/signup_spec.rb
+++ b/spec/graphql/mutations/users/signup_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Mutations::Users::Signup, type: :request do
   let!(:variables) do
     {
+      password: '123456789',
       userAttributes: {
         email: 'vince@example.com',
-        password: '123456789',
         firstName: 'Vince',
         lastName: 'Yoon',
         gender: 'male',
@@ -50,7 +50,7 @@ RSpec.describe Mutations::Users::Signup, type: :request do
 
     context 'with invalid signup info' do
       it 'shorten password length' do
-        response = execute_and_parse_graphql_response query: signup_query, variables: variables.deep_merge(userAttributes: { password: '123' })
+        response = execute_and_parse_graphql_response query: signup_query, variables: variables.merge(password: '1234')
         expect(response['signup']).to match(
           token: 'Invalid',
           errors: ['Password is too short (minimum is 8 characters)']


### PR DESCRIPTION
Structuring mutation input arguments and query type fields.
Instead of using the Graphql base file, it is inherited and used.